### PR TITLE
Replace internal deeply clone function call

### DIFF
--- a/lib/create_new.js
+++ b/lib/create_new.js
@@ -1,5 +1,5 @@
 var os            = require('os')
-  , cloneFunction = require('deeply/lib/clone_function')
+  , cloneFunction = require('fulcon')
   , merge         = require('deeply')
   , configly      = require('./configly.js')
   ;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "compare-property": "^2.0.0",
     "deeply": "^2.0.1",
+    "fulcon": "^1.0.1",
     "precise-typeof": "^1.0.2",
     "stripbom": "^3.0.0"
   },


### PR DESCRIPTION
Seems deeply was updated to remove `lib/create_new.js`. This PR replaces that call with fulcon, the same library that is used in deeply.